### PR TITLE
Improve linkedlist.c clear() and add Player.c clear Command

### DIFF
--- a/libs/linkedlist.c
+++ b/libs/linkedlist.c
@@ -49,6 +49,7 @@ void clear(){
     Node* temp = _head;
     while(temp != NULL){
         temp = temp->next;
+        free(_head->data);
         free(_head);
         _head = temp;
     }

--- a/src/Player.c
+++ b/src/Player.c
@@ -36,7 +36,7 @@ void getCommand(char* command) {
     } else if (strcmp(command, "clear") == 0) {
         // 재생 목록을 비움 --> LinkedList is cleared!
         // need clear()
-
+		clear();
     } else if (strcmp(command, "quit") == 0) {
         // clear를 실행 후 뮤직 플레이어를 종료함 --> quit!
         // need clear()


### PR DESCRIPTION
append와 append_left에서 new_node->data를 malloc하였기에 
clear()에 free도 같이 넣어주었습니다.
Player.c의 Command clear를 구현하였습니다.